### PR TITLE
Added note to README that SVG favicon are not supported in Safari in 01. Links to Public Files

### DIFF
--- a/exercises/01.styling/01.problem.public-links/README.mdx
+++ b/exercises/01.styling/01.problem.public-links/README.mdx
@@ -63,5 +63,9 @@ export default function App() {
 🦉 Tip: Check the network tab in the app on the home page. You'll know you got
 it right when you see the `favicon.svg` file loaded.
 
+<callout-warning>
+	SVG favicons are not currently supported in Safari. See [caniuse](https://caniuse.com/link-icon-svg) for browser support.
+</callout-warning>
+
 - [📜 `links` export](https://remix.run/docs/en/main/route/links)
 - [📜 `<Links />`](https://remix.run/docs/en/main/components/links)


### PR DESCRIPTION
Added note to README that SVG favicon are not supported in Safari in 01. Links to Public Files.

https://caniuse.com/link-icon-svg