### PR TITLE
Added note to README that SVG favicon are not supported in Safari in 02. Asset Imports

### DIFF
--- a/exercises/01.styling/02.problem.asset-imports/README.mdx
+++ b/exercises/01.styling/02.problem.asset-imports/README.mdx
@@ -35,4 +35,8 @@ import faviconAssetUrl from './assets/favicon.svg'
 
 And use `faviconAssetUrl` instead of the hard-coded URL.
 
+<callout-warning>
+	SVG favicons are not currently supported in Safari. See [caniuse](https://caniuse.com/link-icon-svg) for browser support.
+</callout-warning>
+
 - [📜 Remix Config for `assetsBuildDirectory`](https://remix.run/docs/en/main/file-conventions/remix-config#assetsbuilddirectory) (this is how you configure where Remix puts fingerprinted assets)


### PR DESCRIPTION
Added note to README that SVG favicon are not supported in Safari in 01. Links to Public Files.

https://caniuse.com/link-icon-svg