### PR TITLE
Fix typo in exercise README

### DIFF
--- a/exercises/README.mdx
+++ b/exercises/README.mdx
@@ -12,7 +12,7 @@ oriented and to give you your assignments for the day. We're going to get a new
 project for note taking off the ground. We want people to write Epic Notes 💪
 
 Today, you're going to be working on the Epic Notes app adding key features
-and fixing significant bugs in an brand new application. Just as if you had been
+and fixing significant bugs in a brand new application. Just as if you had been
 hired to work with us today. Throughout the workshop, you'll learn important
 foundational skills of web app development including:
 


### PR DESCRIPTION
`an` is grammatically incorrect here, as `brand` starts with a consonant.