### PR TITLE
update link for regular stylesheets on styling, lesson 3

### DIFF
--- a/exercises/01.styling/03.problem.global-styles/README.mdx
+++ b/exercises/01.styling/03.problem.global-styles/README.mdx
@@ -16,4 +16,4 @@ favicon work you've already done, but you'll use `rel="stylesheet"`. When you're
 done, the `<link>` should be something like:
 `<link rel="stylesheet" href="/build/_assets/font-SBXW2PKK.css"/>`.
 
-- [📜 Remix Styling Docs: Regular Stylesheets](https://remix.run/docs/en/main/guides/styling#regular-stylesheets)
+- [📜 Remix Styling Docs: Regular Stylesheets](https://remix.run/docs/en/main/styling/css#regular-css)


### PR DESCRIPTION
the link on the lesson points to:
> https://remix.run/docs/en/main/guides/styling#regular-stylesheets

but it seems the docs on remix moved to:
> https://remix.run/docs/en/main/styling/css

in fact, navigating to the linked resource redirects the user to:
> https://remix.run/docs/en/main/styling/bundling#regular-stylesheets