### PR TITLE
Update Resource Route URL

### DIFF
--- a/exercises/02.routing/04.problem.resources/README.mdx
+++ b/exercises/02.routing/04.problem.resources/README.mdx
@@ -73,4 +73,4 @@ and all you see is "OK".
   either use a regular `<a>` or add the `reloadDocument` prop to the Link.
 </callout-warning>
 
-- [📜 Resource Routes](https://remix.run/docs/en/1.18.1/guides/resource-routes)
+- [📜 Resource Routes](https://remix.run/docs/en/main/guides/resource-routes)


### PR DESCRIPTION
The current URL links to the old documentation page for Remix. When you land on this page, the suggestion is to navigate to the new docs. Since we link the new Resources Routes url earlier in the document, this change seems appropriate.