### PR TITLE
Update example to match `meta` function attr name

### DIFF
--- a/exercises/06.seo/README.mdx
+++ b/exercises/06.seo/README.mdx
@@ -164,10 +164,10 @@ import { json } from '@remix-run/node'
 import { type MetaFunction } from '@remix-run/react'
 import { getSandwich } from '../sandwiches.server'
 
-export const meta: MetaFunction<typeof loader> = ({ loaderData }) => {
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
 	return [
-		{ title: loaderData.sandwich.name },
-		{ name: 'description', content: loaderData.sandwich.description },
+		{ title: data.sandwich.name },
+		{ name: 'description', content: data.sandwich.description },
 	]
 }
 


### PR DESCRIPTION
In "06. Search Engine Optimization / Intro" the text shows an example of how we can bring dynamic values from the `loader` function by receiving the data through the `loaderData` parameter.

The real name of the parameter, based on "06. Search Engine Optimization / 03. Dynamic meta export", and the [Remix docs](https://remix.run/docs/en/main/route/meta#data), is `data`.

This change updates the parameter in the `README.mdx` file to match the real name, so people don't end up confused after reading the Intro and seeing a different value come up in an exercise later on.