### PR TITLE
Fix "Kody's Notes" link in root layouts of the Scripts unit's problems and solutions

### DIFF
--- a/exercises/05.scripting/01.problem.scripts/app/root.tsx
+++ b/exercises/05.scripting/01.problem.scripts/app/root.tsx
@@ -33,7 +33,7 @@ export default function App() {
 							<div className="font-light">epic</div>
 							<div className="font-bold">notes</div>
 						</Link>
-						<Link className="underline" to="users/kody/notes/d27a197e">
+						<Link className="underline" to="users/kody/notes">
 							Kody's Notes
 						</Link>
 					</nav>

--- a/exercises/05.scripting/01.solution.scripts/app/root.tsx
+++ b/exercises/05.scripting/01.solution.scripts/app/root.tsx
@@ -41,7 +41,7 @@ export default function App() {
 							<div className="font-light">epic</div>
 							<div className="font-bold">notes</div>
 						</Link>
-						<Link className="underline" to="users/kody/notes/d27a197e">
+						<Link className="underline" to="users/kody/notes">
 							Kody's Notes
 						</Link>
 					</nav>

--- a/exercises/05.scripting/02.problem.scroll-restoration/app/root.tsx
+++ b/exercises/05.scripting/02.problem.scroll-restoration/app/root.tsx
@@ -41,7 +41,7 @@ export default function App() {
 							<div className="font-light">epic</div>
 							<div className="font-bold">notes</div>
 						</Link>
-						<Link className="underline" to="users/kody/notes/d27a197e">
+						<Link className="underline" to="users/kody/notes">
 							Kody's Notes
 						</Link>
 					</nav>

--- a/exercises/05.scripting/02.solution.scroll-restoration/app/root.tsx
+++ b/exercises/05.scripting/02.solution.scroll-restoration/app/root.tsx
@@ -42,7 +42,7 @@ export default function App() {
 							<div className="font-light">epic</div>
 							<div className="font-bold">notes</div>
 						</Link>
-						<Link className="underline" to="users/kody/notes/d27a197e">
+						<Link className="underline" to="users/kody/notes">
 							Kody's Notes
 						</Link>
 					</nav>

--- a/exercises/05.scripting/03.problem.custom-scripts/app/root.tsx
+++ b/exercises/05.scripting/03.problem.custom-scripts/app/root.tsx
@@ -43,7 +43,7 @@ export default function App() {
 							<div className="font-light">epic</div>
 							<div className="font-bold">notes</div>
 						</Link>
-						<Link className="underline" to="users/kody/notes/d27a197e">
+						<Link className="underline" to="users/kody/notes">
 							Kody's Notes
 						</Link>
 					</nav>

--- a/exercises/05.scripting/03.solution.custom-scripts/app/root.tsx
+++ b/exercises/05.scripting/03.solution.custom-scripts/app/root.tsx
@@ -43,7 +43,7 @@ export default function App() {
 							<div className="font-light">epic</div>
 							<div className="font-bold">notes</div>
 						</Link>
-						<Link className="underline" to="users/kody/notes/d27a197e">
+						<Link className="underline" to="users/kody/notes">
 							Kody's Notes
 						</Link>
 					</nav>

--- a/exercises/05.scripting/04.problem.prefetching/app/root.tsx
+++ b/exercises/05.scripting/04.problem.prefetching/app/root.tsx
@@ -43,7 +43,7 @@ export default function App() {
 							<div className="font-light">epic</div>
 							<div className="font-bold">notes</div>
 						</Link>
-						<Link className="underline" to="users/kody/notes/d27a197e">
+						<Link className="underline" to="users/kody/notes">
 							Kody's Notes
 						</Link>
 					</nav>

--- a/exercises/05.scripting/04.solution.prefetching/app/root.tsx
+++ b/exercises/05.scripting/04.solution.prefetching/app/root.tsx
@@ -43,7 +43,7 @@ export default function App() {
 							<div className="font-light">epic</div>
 							<div className="font-bold">notes</div>
 						</Link>
-						<Link className="underline" to="users/kody/notes/d27a197e">
+						<Link className="underline" to="users/kody/notes">
 							Kody's Notes
 						</Link>
 					</nav>

--- a/exercises/05.scripting/05.problem.pending/app/root.tsx
+++ b/exercises/05.scripting/05.problem.pending/app/root.tsx
@@ -43,7 +43,7 @@ export default function App() {
 							<div className="font-light">epic</div>
 							<div className="font-bold">notes</div>
 						</Link>
-						<Link className="underline" to="users/kody/notes/d27a197e">
+						<Link className="underline" to="users/kody/notes">
 							Kody's Notes
 						</Link>
 					</nav>

--- a/exercises/05.scripting/05.solution.pending/app/root.tsx
+++ b/exercises/05.scripting/05.solution.pending/app/root.tsx
@@ -43,7 +43,7 @@ export default function App() {
 							<div className="font-light">epic</div>
 							<div className="font-bold">notes</div>
 						</Link>
-						<Link className="underline" to="users/kody/notes/d27a197e">
+						<Link className="underline" to="users/kody/notes">
 							Kody's Notes
 						</Link>
 					</nav>


### PR DESCRIPTION
If you delete the note with ID `d27a197e` then the root layout's "Kody's Notes" link will lead to a 404. I confirmed this link goes to `users/kody/notes` in the Data Mutations unit of Full Stack Foundations. If this PR is accepted, I'd be willing to fix it in the SEO and Error Handling units as well.