### PR TITLE
Fix charSet capitalization and missing word in SEO intro

### DIFF
--- a/exercises/06.seo/README.mdx
+++ b/exercises/06.seo/README.mdx
@@ -110,7 +110,7 @@ export default function App() {
 				<title>My Page</title>
 				<meta name="description" content="This is my page" />
 				<meta name="viewport" content="width=device-width, initial-scale=1" />
-				<meta charset="utf-8" />
+				<meta charSet="utf-8" />
 			</head>
 			<body>{/* ... */}</body>
 		</html>
@@ -146,7 +146,7 @@ and `</html>` and that's no different here. You need to apply the
 `<head>` of your document in your `app/root.tsx` to ensure these meta tags are
 rendered. Much like the `<Links />` component.
 
-With that example above, the `<head>` of your document have this:
+With that example above, the `<head>` of your document would have this:
 
 ```html
 <title>Sandwich Shop</title>


### PR DESCRIPTION
I imagine the capitalization of React props would make for a fun quiz, depending on your definition of fun! 😂