### PR TITLE
Adjust errant comma in 04.problem.compiling-css

### DIFF
--- a/exercises/01.styling/04.problem.compiling-css/README.mdx
+++ b/exercises/01.styling/04.problem.compiling-css/README.mdx
@@ -51,7 +51,7 @@ export default {
 
 This is where we configure [Tailwind](https://tailwindcss.com), a CSS framework
 that we'll be using to style our app. Our PostCSS configuration includes the
-Tailwind plugin so, we can use the Tailwind directives in our css files to get
+Tailwind plugin so we can use the Tailwind directives in our css files to get
 the Tailwind stylesheet on the page. 📜 You can read more about configuring
 Tailwind with PostCSS in
 [the Tailwind docs](https://tailwindcss.com/docs/using-with-preprocessors).


### PR DESCRIPTION
Micro nitpick change. The current comma location breaks the flow of the sentence in an unexpected way. It could be moved to be `plugin, so...`, or I think can be completely deleted.

This PR simply removes it.