### PR TITLE
Fix false positive test

### DIFF
--- a/exercises/01.styling/01.solution.public-links/tests/e2e/favicon.test.ts
+++ b/exercises/01.styling/01.solution.public-links/tests/e2e/favicon.test.ts
@@ -3,6 +3,6 @@ import { test, expect } from '@playwright/test'
 test('checks favicon', async ({ page }) => {
 	await page.goto('/')
 	const favicon = await page.$('link[rel="icon"]')
-	const href = await favicon?.getAttribute('href') ?? null
-	expect(href, `🚨 The favicon link href cannot be found`).not.toBeNull()
+	const href = await favicon?.getAttribute('href')
+	expect(href, `🚨 The favicon link href cannot be found`).toBeTruthy()
 })

--- a/exercises/01.styling/01.solution.public-links/tests/e2e/favicon.test.ts
+++ b/exercises/01.styling/01.solution.public-links/tests/e2e/favicon.test.ts
@@ -3,6 +3,6 @@ import { test, expect } from '@playwright/test'
 test('checks favicon', async ({ page }) => {
 	await page.goto('/')
 	const favicon = await page.$('link[rel="icon"]')
-	const href = await favicon?.getAttribute('href')
+	const href = await favicon?.getAttribute('href') ?? null
 	expect(href, `🚨 The favicon link href cannot be found`).not.toBeNull()
 })


### PR DESCRIPTION
 On exercises/01.styling/01.solution.public-links, the test is expected to test against a nullable value where it could be an undefined. To fix this, either make the testing value a nullable or use a more suitable value assertion https://playwright.dev/docs/api/class-genericassertions#methods