### PR TITLE
Add layout nesting tip to the SEO chapters

### DIFF
--- a/exercises/06.seo/02.solution.nested/README.mdx
+++ b/exercises/06.seo/02.solution.nested/README.mdx
@@ -19,7 +19,7 @@ for our profile pages.
 	they won't be "layout-nested", even if they will be "url-nested". And, because
 	they won't be layout-nested, they won't inherit the meta override defined
 	in the `routes/users+/$username.tsx`, following, instead, the meta override
-	defined in the `routes/root.tsx` which its parent regarding layout. One way
+	defined in the `routes/root.tsx` which is its parent regarding layout. One way
 	of seeing the layout parent-child relationships is by typing the 
 	`npx remix routes` in a terminal at the root of a remix project to see how
 	the routes will be configured. It should give you a better view of the

--- a/exercises/06.seo/02.solution.nested/README.mdx
+++ b/exercises/06.seo/02.solution.nested/README.mdx
@@ -4,3 +4,24 @@
 
 👨‍💼 Great! Now we can customize the meta tags on our routes! Let's do a bit more
 for our profile pages.
+
+<callout-info>
+	🦉 You'll notice that if you navigate to the `/users/kody` route, you'll see
+	the `Profile | Epic Notes` in the title. But you'll see only `Epic Notes`
+	when you navigate to one of its child URLs, like `/users/kody/notes`. It
+	behaves like that because, regardless the 2 URLs have a parent-child
+	relationship, in terms of layout, `/users/kody/notes` is not a child of 
+	`/users/kody`. Remember that the latter folder path is defined like this:
+	`routes/users+/$username.tsx` while the former's path is
+	`routes/users+/$username_+/notes.tsx`. That little underscore in the name of
+	the folder `$username_+` means that the pages inside will skip using the
+	layout defined in the `routes/users+/$username.tsx` file. In other words,
+	they won't be "layout-nested", even if they will be "url-nested". And, because
+	they won't be layout-nested, they won't inherit the meta override defined
+	in the `routes/users+/$username.tsx`, following, instead, the meta override
+	defined in the `routes/root.tsx` which its parent regarding layout. One way
+	of seeing the layout parent-child relationships is by typing the 
+	`npx remix routes` in a terminal at the root of a remix project to see how
+	the routes will be configured. It should give you a better view of the
+	router layout-nesting structure.
+</callout-info>


### PR DESCRIPTION
It can be confusing to people that once they set the `meta` override to the `app/routes/users+/$username.tsx` file, the pages in the child URLs seem to ignore the overridden information.

This PR adds some notes on the solution page of the "Meta Overrides" activity to refresh the concept of "layout-nesting" vs "url-nesting", already shown in the "Routes" part.