### PR TITLE
Update LoaderFunctionArgs instead of outdated  DataFunctionArgs in README.mdx for Data Loading module

### DIFF
--- a/exercises/03.loading/README.mdx
+++ b/exercises/03.loading/README.mdx
@@ -81,9 +81,9 @@ environment variables, etc. It receives the `Request` object and `params` object
 and should return a `Response` object. For example:
 
 ```tsx
-import { type DataFunctionArgs } from '@remix-run/node'
+import { type LoaderFunctionArgs } from '@remix-run/node'
 
-export async function loader({ request, params }: DataFunctionArgs) {
+export async function loader({ request, params }: LoaderFunctionArgs) {
 	const dataString = JSON.stringify({ hello: 'world' })
 	return new Response(dataString, {
 		headers: { 'content-type': 'application/json' },
@@ -96,9 +96,9 @@ exports a utility called `json` which allows you to more easily create a JSON
 object:
 
 ```tsx
-import { json, type DataFunctionArgs } from '@remix-run/node'
+import { json, type LoaderFunctionArgs } from '@remix-run/node'
 
-export async function loader({ request, params }: DataFunctionArgs) {
+export async function loader({ request, params }: LoaderFunctionArgs) {
 	return json({ hello: 'world' })
 }
 ```
@@ -108,10 +108,10 @@ Then the UI code can use the
 from `@remix-run/react` which will return the data from the `loader` function.
 
 ```tsx
-import { json, type DataFunctionArgs } from '@remix-run/node'
+import { json, type LoaderFunctionArgs } from '@remix-run/node'
 import { useLoaderData } from '@remix-run/react'
 
-export async function loader({ request, params }: DataFunctionArgs) {
+export async function loader({ request, params }: LoaderFunctionArgs) {
 	return json({ hello: 'world' })
 }
 


### PR DESCRIPTION
Update LoaderFunctionArgs instead of outdated 

'DataFunctionArgs' is deprecated.ts(6385)
routeModules.d.ts(9, 4): The declaration was marked as deprecated here. (alias) type DataFunctionArgs = RRActionFunctionArgs<AppLoadContext> & RRLoaderFunctionArgs<AppLoadContext> & {
    context: AppLoadContext;
}
import DataFunctionArgs
@deprecated — Use LoaderFunctionArgs/ActionFunctionArgs instead